### PR TITLE
Fix result caching

### DIFF
--- a/dmarc.pm
+++ b/dmarc.pm
@@ -182,7 +182,7 @@ sub _check_dmarc {
     return 0;
   }
 
-  if((defined $self->{dmarc_checked}) and ($self->{dmarc_checked} eq 1)) {
+  if((defined $pms->{dmarc_checked}) and ($pms->{dmarc_checked} eq 1)) {
     return;
   }
   $dmarc = Mail::DMARC::PurePerl->new();


### PR DESCRIPTION
The dmarc_checked var should be in $pms and not $self

This caused validate to be run 3 times instead of once