### PR TITLE
Fix domain source of SPF with `mfrom` scope

### DIFF
--- a/Dmarc.pm
+++ b/Dmarc.pm
@@ -233,7 +233,7 @@ sub _check_dmarc {
   $spf_helo_status = 'neutral' if ((defined $pms->{spf_helo_neutral}) and ($pms->{spf_helo_neutral} eq 1));
   $spf_helo_status = 'softfail' if ((defined $pms->{spf_helo_softfail}) and ($pms->{spf_helo_softfail} eq 1));
 
-  $mfrom_domain = $pms->get('From:domain');
+  $mfrom_domain = $pms->get('EnvelopeFrom:domain');
   return if not defined $mfrom_domain;
   $dmarc->source_ip($lasthop->{ip});
   $dmarc->header_from_raw($pms->get('From:addr'));


### PR DESCRIPTION
According to https://metacpan.org/pod/Mail::SPF::Request#mfrom, the domain that should be checked for SPF requests of scope `mfrom` should be the one appearing in envelope sender address.

Currently the domain used is the one appearing in the sender address appearing in the headers. This makes the SPF alignment always be true.